### PR TITLE
Add a new <TEAM>_mom gauge with component and status labels

### DIFF
--- a/metrics/merges.py
+++ b/metrics/merges.py
@@ -31,6 +31,8 @@ def get_merge_data(team_name):
     for entry in entries:
         entry_parts = entry.strip().split(' ')
         component = entry_parts[2]
+        if component != 'main':
+            continue
         values = entry_parts[3:]
         for value in values:
             key, value = value.split('=')


### PR DESCRIPTION
In addition the existing <TEAM>_mom_* gauges, this adds a single
<TEAM>_mom gauge with labels that allow us to decompose by component and
label at the prometheus level.