### PR TITLE
Only import the git module in the function that needs it.

### DIFF
--- a/metrics/helpers/util.py
+++ b/metrics/helpers/util.py
@@ -37,8 +37,8 @@ def bzr_contributors(pkg):
 
 
 def git_contributors(git_url):
-    import git
     """Return numbers on git project contributors."""
+    import git
     with tempfile.TemporaryDirectory() as temp:
         print('Cloning %s into %s' % (git_url, temp))
         git.Repo.clone_from(git_url, temp)

--- a/metrics/helpers/util.py
+++ b/metrics/helpers/util.py
@@ -19,7 +19,6 @@ except ImportError:
     from urllib2 import URLError
     from urllib2 import urlopen
 
-import git
 from prometheus_client import push_to_gateway
 
 INSTANCE = 'ubuntu-server'
@@ -38,6 +37,7 @@ def bzr_contributors(pkg):
 
 
 def git_contributors(git_url):
+    import git
     """Return numbers on git project contributors."""
     with tempfile.TemporaryDirectory() as temp:
         print('Cloning %s into %s' % (git_url, temp))


### PR DESCRIPTION
This way you can run a metric that doesn't use git_contributors without having to install python3-git or whatever the package is.