### PR TITLE
Age and count of unreleaseable packages in -proposed

### DIFF
--- a/metrics/foundations_sru.py
+++ b/metrics/foundations_sru.py
@@ -329,7 +329,7 @@ def collect(dryrun=False):
                     proposed_sru_age_data[series]
                     ['fourteen_day_%s_backlog_count' % cat])
 
-        util.push2gateway('triage', registry)
+        util.push2gateway('foundations-sru', registry)
 
 
 if __name__ == '__main__':

--- a/metrics/foundations_sru.py
+++ b/metrics/foundations_sru.py
@@ -62,7 +62,8 @@ def sru_ages():
                            upload.date_created.replace(tzinfo=None)).days
             if age_in_days > oldest_age_in_days:
                 oldest_age_in_days = age_in_days
-            # items in the queue for > 10 days should be considered late
+            # items in the queue for > 10 days have gone through at least a
+            # weeks worth of reviewers and should be considered late
             if age_in_days > 10:
                 backlog_age += age_in_days - 10
                 backlog_count += 1

--- a/metrics/foundations_sru.py
+++ b/metrics/foundations_sru.py
@@ -169,7 +169,6 @@ def proposed_package_ages():
                         'Dependency wait' in failure or
                         'Cancelled' in failure or
                         'Regression in autopkgtest' in failure):
-                    verified = False
                     category = 'unverified'
                 for bug in bugs:
                     # vfailed will overwrite the unverified status of an SRU
@@ -181,7 +180,7 @@ def proposed_package_ages():
                         break
                     if 'verified' in bug['class']:
                         # if it is unverified for any reason then it can't be
-                        # isn't verified i.e. every bug needs verification
+                        # verified i.e. every bug needs verification
                         if category != 'unverified':
                             category = 'verified'
                 if category == 'unverified':

--- a/metrics/foundations_sru.py
+++ b/metrics/foundations_sru.py
@@ -308,23 +308,26 @@ def collect(dryrun=False):
         for series, count in ready_srus.items():
             gauge.labels(series).set(count)
 
-        gauge = Gauge(
-            'distro_sru_unreleaseable_proposed_fourteen_day_backlog_age',
-            'Backlog age in days of Unreleasable %s' % category,
-            ['series'],
-            registry=registry)
-        for series in proposed_sru_age_data:
-            gauge.labels(series).set(
-                proposed_sru_age_data[series]['fourteen_day_backlog_age'])
+        for cat in ('unverified', 'verified', 'vfailed'):
+            gauge = Gauge(
+                'distro_sru_%s_proposed_fourteen_day_backlog_age' % cat,
+                'Backlog age in days of %s %s' % (cat, topic),
+                ['series'],
+                registry=registry)
+            for series in proposed_sru_age_data:
+                gauge.labels(series).set(
+                    proposed_sru_age_data[series]
+                    ['fourteen_day_%s_backlog_age' % cat])
 
-        gauge = Gauge(
-            'distro_sru_unreleaseable_proposed_fourteen_day_backlog_count',
-            'Number of backlogged Unreleasable %s' % category,
-            ['series'],
-            registry=registry)
-        for series in proposed_sru_age_data:
-            gauge.labels(series).set(
-                proposed_sru_age_data[series]['fourteen_day_backlog_count'])
+            gauge = Gauge(
+                'distro_sru_%s_proposed_fourteen_day_backlog_count' % cat,
+                'Number of backlogged %s %s' % (cat, topic),
+                ['series'],
+                registry=registry)
+            for series in proposed_sru_age_data:
+                gauge.labels(series).set(
+                    proposed_sru_age_data[series]
+                    ['fourteen_day_%s_backlog_count' % cat])
 
         util.push2gateway('triage', registry)
 


### PR DESCRIPTION
I made some changes to the account for some long lines due to the rename of sru_ages to unapproved_sru_ages.  I renamed that function since we now have two functions regarding SRU age, one for unapproved and one for SRUs in -proposed.

Fourteen days seems like a reasonable grace period for a developer to verify an SRU or look at autopkgtest / build failures which are causing the package to be unreleaseable.  Here's a print of the results fwiw:

Number of backlogged Unreleasable Updates in Proposed per Series:
precise: 1
trusty: 4
xenial: 19
zesty: 16
Backlog age in days of Unreleasable Updates in Proposed per Series
precise: 145
trusty: 276
xenial: 1725
zesty: 511
