### PR TITLE
Add security team to the list of teams using the metrics

### DIFF
--- a/metrics/helpers/util.py
+++ b/metrics/helpers/util.py
@@ -95,6 +95,7 @@ def get_launchpad_team_name(team):
     mapping = {
         'foundations': 'foundations-bugs',
         'server': 'ubuntu-server',
+        'security': 'ubuntu-security',
     }
     return mapping[team]
 


### PR DESCRIPTION
The Security Team is using your bug-triage metrics for the security kpis. To make it work without a local code change, adding security to the list of teams is one of the two changes required. The other is avoiding hardcoded INSTANCE name, but that is not included in this pull request.