### PR TITLE
influxdb support

### DIFF
--- a/metrics/helpers/util.py
+++ b/metrics/helpers/util.py
@@ -19,6 +19,7 @@ except ImportError:
     from urllib2 import URLError
     from urllib2 import urlopen
 
+from influxdb import InfluxDBClient
 from prometheus_client import push_to_gateway
 
 INSTANCE = 'ubuntu-server'
@@ -99,6 +100,32 @@ def get_launchpad_team_name(team):
         'openstack': 'ubuntu-openstack',
     }
     return mapping[team]
+
+
+def influxdb_connect():
+    """Connect to an InfluxDB instance."""
+    try:
+        hostname = os.environ['INFLUXDB_HOSTNAME']
+        port = os.environ['INFLUXDB_PORT']
+        username = os.environ['INFLUXDB_USERNAME']
+        password = os.environ['INFLUXDB_PASSWORD']
+        database = os.environ['INFLUXDB_DATABASE']
+    except KeyError:
+        print('error: please source influx credentials before running')
+        sys.exit(1)
+
+    return InfluxDBClient(hostname, port, username, password, database)
+
+
+def influxdb_insert(data):
+    """Write given data to InfluxDB.
+
+    @param data: array of dictionaries of data
+    """
+    client = influxdb_connect()
+
+    if data:
+        client.write_points(data)
 
 
 def run(cmd):

--- a/metrics/iso.py
+++ b/metrics/iso.py
@@ -9,7 +9,6 @@ import re
 import urllib.request
 
 import distro_info
-from prometheus_client import CollectorRegistry, Gauge
 
 from metrics.helpers import util
 
@@ -67,59 +66,18 @@ def collect(dryrun=False):
 
     if not dryrun:
         print('Pushing data...')
-        registry = CollectorRegistry()
+        data = [
+            {
+                'measurement': 'iso_size_devel',
+                'fields': devel_results,
+            },
+            {
+                'measurement': 'iso_size_lts',
+                'fields': lts_results,
+            }
+        ]
 
-        Gauge('server_iso_devel_amd64_size_total',
-              'dev amd64 size',
-              None,
-              registry=registry).set(devel_results['amd64'])
-
-        Gauge('server_iso_devel_arm64_size_total',
-              'dev arm64 size',
-              None,
-              registry=registry).set(devel_results['arm64'])
-
-        Gauge('server_iso_devel_i386_size_total',
-              'dev i386 size',
-              None,
-              registry=registry).set(devel_results['i386'])
-
-        Gauge('server_iso_devel_ppc64el_size_total',
-              'dev ppc64el size',
-              None,
-              registry=registry).set(devel_results['ppc64el'])
-
-        Gauge('server_iso_devel_s390x_size_total',
-              'dev s390x size',
-              None,
-              registry=registry).set(devel_results['s390x'])
-
-        Gauge('server_iso_lts_amd64_size_total',
-              'lts amd64 size',
-              None,
-              registry=registry).set(lts_results['amd64'])
-
-        Gauge('server_iso_lts_arm64_size_total',
-              'lts arm64 size',
-              None,
-              registry=registry).set(lts_results['arm64'])
-
-        Gauge('server_iso_lts_i386_size_total',
-              'lts i386 size',
-              None,
-              registry=registry).set(lts_results['i386'])
-
-        Gauge('server_iso_lts_ppc64el_size_total',
-              'lts ppc64el size',
-              None,
-              registry=registry).set(lts_results['ppc64el'])
-
-        Gauge('server_iso_lts_s390x_size_total',
-              'lts s390x size',
-              None,
-              registry=registry).set(lts_results['s390x'])
-
-        util.push2gateway('server-iso', registry)
+        util.influxdb_insert(data)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-    bs4
-    httplib2
-    gitpython
-    google-api-python-client
-    prometheus_client
-    psycopg2
-    requests
-    simplejson
+bs4
+gitpython
+google-api-python-client
+httplib2
+influxdb
+prometheus_client
+psycopg2
+requests
+simplejson
+

--- a/tools/csv2influx.py
+++ b/tools/csv2influx.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Load CSV file data and push to InfluxDB."""
+import argparse
+import csv
+
+from metrics.helpers import util
+
+
+def csv2influx(csv_filename, measurement):
+    """
+    Push CSV data to InfluxDB.
+
+    @param csv_filename: csv filename to load into InfluxDB
+    @param measurement: measurement name to use for data
+    """
+    data = []
+    with open(csv_filename) as csv_file:
+        reader = csv.DictReader(csv_file)
+        for row in reader:
+            date = row.pop('date')
+            entry = {
+                "measurement": measurement,
+                "fields": dict(row),
+                "time": date
+            }
+            data.append(entry)
+
+    util.influxdb_insert(data)
+
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument('csv',
+                        help='csv file to inject into influxdb')
+    PARSER.add_argument('--measurement', required=True,
+                        help='Name of measurement')
+    PARSER.add_argument('--database',
+                        help='')
+
+    ARGS = PARSER.parse_args()
+
+    csv2influx(ARGS.csv, ARGS.measurement)

--- a/tools/prometheus2csv.py
+++ b/tools/prometheus2csv.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Query Prometheus for a particular metric and optionally specific labels."""
+import argparse
+from collections import defaultdict
+from datetime import datetime, timedelta
+import sys
+
+import requests
+
+from metrics.helpers import util
+
+
+def print_result(date, value):
+    """
+    Print the results in CSV format.
+
+    @param date: Date from Prometheus to convert to rfc3339 date
+    @param value: Values to print out
+    """
+    # convert unix timestamp to rfc3339 (YYYY-MM-DDTHH:MM:SS)
+    rfc3339 = datetime.fromtimestamp(date).isoformat('T') + 'Z'
+    print('%s,%s' % (rfc3339, value))
+
+
+def print_simple(results, metric):
+    """
+    Print single dimentional result.
+
+    @param results: results returned by query
+    @param metric: metric name
+    """
+    print('date,%s' % (metric))
+    for data in results[0]['values']:
+        print_result(data[0], data[1])
+
+
+def print_multi_result(results, label):
+    """
+    Print result with multiple dimentions due to labels.
+
+    @param results: results returned by query
+    @param label: specific label to look for in results
+    """
+    headers = []
+    data = defaultdict(defaultdict)
+    for result in results:
+        try:
+            header = result['metric'][label]
+        except KeyError:
+            print('cannot find label \'%s\' choose from:' % label)
+            print(', '.join(results[0]['metric'].keys()))
+            sys.exit(1)
+
+        headers.append(header)
+        for value in result['values']:
+            data[value[0]][header] = value[1]
+
+    print('date,%s' % ','.join(headers))
+    for date, values in data.items():
+        print_result(date, ','.join(values.values()))
+
+
+def query(url, params):
+    """
+    Query Prometheus for data.
+
+    @param url: URL to query against (e.g. http://IP:PORT/api/v1/query_range)
+    @param params: dictionary of parameters
+    """
+    response = requests.get(url, params=params)
+    if response.status_code != 200:
+        print('%s %s: %s' % (response.status_code, response.reason,
+                             response.text))
+        sys.exit(1)
+
+    results = response.json()['data']['result']
+
+    if not results:
+        print('no result')
+        sys.exit(1)
+
+    return results
+
+
+def runner(metric, label, days, step):
+    """
+    Query Prometheus for specific metric print out csv output.
+
+    @param metric: name of metric to get
+    @param label_key: use specified label key instead of metric name
+    @param days: number of days to get data for
+    @param step: time step in results
+    """
+    server_address = util.get_prometheus_ip()
+
+    end_date = datetime.now()
+    start_date = end_date - timedelta(days=int(days))
+
+    url = '%s/api/v1/query_range' % server_address
+    params = {
+        'query': metric,
+        'start': start_date.strftime('%Y-%m-%dT%H:00:00Z'),
+        'end': end_date.strftime('%Y-%m-%dT%H:00:00Z'),
+        'step': step,
+    }
+
+    results = query(url, params)
+
+    if len(results) == 1:
+        print_simple(results, metric)
+    elif label:
+        print_multi_result(results, label)
+    else:
+        print('multi-dimentional results, please specify a label from:')
+        print(', '.join(results[0]['metric'].keys()))
+        print('result data:')
+        print(results[0]['metric'])
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    PARSER.add_argument('metric',
+                        help='metric to lookup in Prometheus')
+    PARSER.add_argument('--label',
+                        help='specific label to use as header')
+    PARSER.add_argument('--days', default=180,
+                        help='How many days of data to get')
+    PARSER.add_argument('--step', default='1h',
+                        help='Interval of results')
+
+    ARGS = PARSER.parse_args()
+
+    runner(ARGS.metric, ARGS.label, ARGS.days, ARGS.step)

--- a/tools/prometheus2csv.py
+++ b/tools/prometheus2csv.py
@@ -60,7 +60,7 @@ def print_multi_result(results, label):
         print_result(date, ','.join(values.values()))
 
 
-def query(url, params):
+def query_prometheus(url, params):
     """
     Query Prometheus for data.
 
@@ -97,14 +97,20 @@ def runner(metric, label, days, step):
     start_date = end_date - timedelta(days=int(days))
 
     url = '%s/api/v1/query_range' % server_address
+
+    if label:
+        query = metric
+    else:
+        query = 'avg(%s)' % metric
+
     params = {
-        'query': metric,
+        'query': query,
         'start': start_date.strftime('%Y-%m-%dT%H:00:00Z'),
         'end': end_date.strftime('%Y-%m-%dT%H:00:00Z'),
         'step': step,
     }
 
-    results = query(url, params)
+    results = query_prometheus(url, params)
 
     if len(results) == 1:
         print_simple(results, metric)


### PR DESCRIPTION
This adds an example of using InfluxDB over Prometheus as the
backend and tools to pull data out of InfluxDB to push over to
Prometheus.

Pushing from CSV to InfluxDB requires you to provide the
measurement name and then assumes that the CSV file
defines each field name.

Pulling from Prometheus to CSV is tricky because of various
changes that were made as well as how some data is
structured with labels, some has none, and some data
was pushed from multiple locations. It is left to the end-user
to clean and combine multiple CSV files before using the
push to InfluxDB script.